### PR TITLE
Assignees & due dates

### DIFF
--- a/importer.rb
+++ b/importer.rb
@@ -81,7 +81,7 @@ board.lists.each do |list|
             IO.copy_stream(file, tmp)
             tmp.close
 
-            mime_type = MIME::Types.type_for(tmp.path).first || MIME::Types['application/octet-stream'].first
+            mime = MIME::Types.type_for(tmp.path).first || MIME::Types['application/octet-stream'].first
 
             task.attach(filename: tmp.path, mime: mime.content_type)
           end


### PR DESCRIPTION
Added support for assignees. Asana can only have a single assignee, while trello doesn't have that concept, so I'm taking the first member on a trello card and setting it as the assignee and then setting the other members as followers.

Also setting the due date on the asana task. And I fixed a bug with attachments.
